### PR TITLE
fixed missing cgi.escape() when running under python3.8

### DIFF
--- a/houseStatic.py
+++ b/houseStatic.py
@@ -31,9 +31,13 @@ import json
 # import IPython
 import jinja2
 import os
-import cgi
 from flask import render_template, request
 import argparse
+
+if sys.version_info >= (3, 8):
+    import html as cgi
+else:
+    import cgi
 
 Error = colored.fg("red") + colored.attr("bold")
 Info = colored.fg("green") + colored.attr("bold")


### PR DESCRIPTION
When running under python 3.8 house throws the following error:

```
[+] Trying to get device..                                                                                                                                                
Exception in thread Thread-33:                                                                                                                                            
Traceback (most recent call last):                                                                                                                                        
  File "/home/merzjo/VMShared/playground/android/house/houseUtil.py", line 235, in getDevice                                                                              
    {'data': cgi.escape(str(house_global.device))},                                                                                                                       
AttributeError: module 'cgi' has no attribute 'escape'                                                                                                                    
                                                                                                                                                                          
During handling of the above exception, another exception occurred:                                                                                                       
                                                                                                                                                                          
Traceback (most recent call last):                                                                                                                                        
  File "/usr/lib64/python3.8/threading.py", line 932, in _bootstrap_inner                                                                                                 
    self.run()                                                                                                                                                            
  File "/usr/lib64/python3.8/threading.py", line 870, in run                                                                                                              
    self._target(*self._args, **self._kwargs)                                                                                                                             
  File "/home/merzjo/VMShared/playground/android/house/venv/lib/python3.8/site-packages/socketio/server.py", line 651, in _handle_event_internal
    r = server._trigger_event(data[0], namespace, sid, *data[1:])
  File "/home/merzjo/VMShared/playground/android/house/venv/lib/python3.8/site-packages/socketio/server.py", line 680, in _trigger_event
    return self.handlers[namespace][event](*args)
  File "/home/merzjo/VMShared/playground/android/house/venv/lib/python3.8/site-packages/flask_socketio/__init__.py", line 283, in _handler
    return self._handle_event(handler, message, namespace, sid,
  File "/home/merzjo/VMShared/playground/android/house/venv/lib/python3.8/site-packages/flask_socketio/__init__.py", line 698, in _handle_event
    ret = handler(*args)
  File "/home/merzjo/VMShared/playground/android/house/houseSock.py", line 56, in wrapped
    return f(*args, **kwargs)
  File "/home/merzjo/VMShared/playground/android/house/houseSock.py", line 90, in refresh_device
    getDevice()
  File "/home/merzjo/VMShared/playground/android/house/houseUtil.py", line 256, in getDevice
    {'data': cgi.escape(str(house_global.device))},
AttributeError: module 'cgi' has no attribute 'escape'
```

The following change seems to resolve that issue. 

Taken from: [tensorflow](https://github.com/tensorflow/tensorboard/pull/3016/commits/db2d849bd359ff16a79dd8aa4c36a299405abd34) 