### PR TITLE
Fix error regarding unsupported version of the Socket.IO by pinning the version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ colored
 frida
 jinja2
 requests
-flask-socketio
+flask-socketio==4.3.2
 flask-login
 ipython


### PR DESCRIPTION
Starting the app gives the following log line, with similar errors in the browser:
`The client is using an unsupported version of the Socket.IO or Engine.IO protocols (further occurrences of this error will be logged with level INFO)`

There is a new Flask-SocketIO version (5.0.0) which got released 5 days ago (Dec 13, 2020) and it has [incompatibilities](https://flask-socketio.readthedocs.io/en/latest/#version-compatibility).

All of the pip requirements should ideally be pinned, this is just a quick fix.

[See original Flask-SocketIO issue here]( https://github.com/miguelgrinberg/Flask-SocketIO/issues/1432).

Also possibly related to https://github.com/nccgroup/house/issues/40 as I had the same issue.